### PR TITLE
If stopped or destroyed, clean up the folder

### DIFF
--- a/lib/Download.js
+++ b/lib/Download.js
@@ -2,8 +2,10 @@ var mtd = require('zeltice-mt-downloader');
 var fs = require('fs');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
+var path = require('path');
 
 var Download = function() {
+	
     EventEmitter.call(this);
 
     this._reset();
@@ -21,6 +23,23 @@ var Download = function() {
 };
 
 util.inherits(Download, EventEmitter);
+
+function rmDir(dirPath, removeSelf) {
+	if (removeSelf === undefined)
+        removeSelf = true;
+	try { var files = fs.readdirSync(dirPath); }
+	catch(e) { return; }
+	if (files.length > 0)
+		for (var i = 0; i < files.length; i++) {
+			var filePath = path.join(dirPath, files[i]);
+			if (fs.statSync(filePath).isFile())
+				fs.unlinkSync(filePath);
+			else
+				rmDir(filePath);
+		}
+	if (removeSelf)
+		fs.rmdirSync(dirPath);
+};
 
 Download.prototype._reset = function(first_argument) {
     this.status = 0; // -3 = destroyed, -2 = stopped, -1 = error, 0 = not started, 1 = started (downloading), 2 = error, retrying, 3 = finished
@@ -224,7 +243,7 @@ Download.prototype.getStats = function() {
 };
 
 Download.prototype._destroyThreads = function() {
-    if(this.meta.threads) {
+	if(this.meta.threads) {
         this.meta.threads.forEach(function(i){
             if(i.destroy) {
                 i.destroy();
@@ -242,12 +261,13 @@ Download.prototype.stop = function() {
 };
 
 Download.prototype.destroy = function() {
+		
     var self = this;
 
     this._destroyThreads();
 
     this.setStatus(-3);
-
+	
     var filePath = this.filePath;
     var tmpFilePath = filePath;
     if (!filePath.match(/\.mtd$/)) {
@@ -255,12 +275,13 @@ Download.prototype.destroy = function() {
     } else {
         filePath = filePath.replace(new RegExp('(.mtd)*$', 'g'), '');
     }
-
+	
     fs.unlink(filePath, function() {
         fs.unlink(tmpFilePath, function() {
             self.emit('destroyed', this);
         });
     });
+	
 };
 
 Download.prototype.start = function() {
@@ -270,7 +291,7 @@ Download.prototype.start = function() {
     self._retryOptions._nbRetries = 0;
 
 	this.options.onStart = function(meta) {
-		self.setStatus(1);
+		self.setStatus(1);		
 		self.setMeta(meta);
 
         self.setUrl(meta.url);
@@ -282,9 +303,20 @@ Download.prototype.start = function() {
         self.emit('start', self);
 	};
 
-	this.options.onEnd = function(err, result) {
-        // If stopped or destroyed, do nothing
+	this.options.onEnd = function(err, result) {		
+        // If stopped or destroyed, clean up the folder
         if(self.status == -2 || self.status == -3) {
+			
+	    setTimeout(function() {
+            	//close file handle
+		fs.close(result["file-handle"], () => {
+			if(self.status == -3){
+				var dirName = path.dirname(self.filePath);
+				rmDir(dirName, false);
+			}
+		});
+            }, 1000);
+			
             return;
         }
 
@@ -337,6 +369,7 @@ Download.prototype.resume = function() {
 
     return this;
 };
+
 
 // For backward compatibility, will be removed in next releases
 Download.prototype.restart = util.deprecate(function() {


### PR DESCRIPTION
I have noticed that if the download is aborted/cancelled, the folder is not being cleaned. So i added a recursive delete folder named rmDir(dirPath, removeSelf), 

please review and let me know, if you see any concern.